### PR TITLE
Upgrade to serde v1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,11 @@ data-encoding = "1.2.0"
 lazy_static = "0.2"
 num = "0.1.37"
 ring = { version = "0.7.5", features = ["rsa_signing"] }
-serde = "0.9"
-serde_derive = "0.9"
-serde_json = { version = "0.9", features = ["preserve_order"] }
+serde = "1.0"
+serde_derive = "1.0"
+serde_json = { version = "1.0", features = ["preserve_order"] }
 untrusted = "0.3"
 url = "^1.0"
 
 [dev-dependencies]
-serde_test = "0.9"
+serde_test = "1.0"

--- a/src/jwa.rs
+++ b/src/jwa.rs
@@ -354,11 +354,8 @@ impl KeyManagementAlgorithm {
     }
 
     /// Retrieve the Content Encryption Key (CEK) based on the algorithm for encryption
-    pub fn cek<'de, T>(&self,
-                       content_alg: ContentEncryptionAlgorithm,
-                       key: &jwk::JWK<T>)
-                       -> Result<jwk::JWK<::Empty>, Error>
-        where T: Serialize + Deserialize<'de>
+    pub fn cek<T>(&self, content_alg: ContentEncryptionAlgorithm, key: &jwk::JWK<T>) -> Result<jwk::JWK<::Empty>, Error>
+        where T: Serialize + for<'de> Deserialize<'de>
     {
         use self::KeyManagementAlgorithm::*;
 
@@ -369,8 +366,8 @@ impl KeyManagementAlgorithm {
         }
     }
 
-    fn cek_direct<'de, T>(&self, key: &jwk::JWK<T>) -> Result<jwk::JWK<::Empty>, Error>
-        where T: Serialize + Deserialize<'de>
+    fn cek_direct<T>(&self, key: &jwk::JWK<T>) -> Result<jwk::JWK<::Empty>, Error>
+        where T: Serialize + for<'de> Deserialize<'de>
     {
         match key.key_type() {
             jwk::KeyType::Octect => Ok(key.clone_without_additional()),
@@ -395,10 +392,10 @@ impl KeyManagementAlgorithm {
     }
 
     /// Encrypt or wrap a key with the provided algorithm
-    pub fn encrypt<'de, T: Serialize + Deserialize<'de>>(&self,
-                                                         payload: &[u8],
-                                                         key: &jwk::JWK<T>)
-                                                         -> Result<EncryptionResult, Error> {
+    pub fn encrypt<T: Serialize + for<'de> Deserialize<'de>>(&self,
+                                                             payload: &[u8],
+                                                             key: &jwk::JWK<T>)
+                                                             -> Result<EncryptionResult, Error> {
         use self::KeyManagementAlgorithm::*;
 
         match *self {
@@ -409,11 +406,11 @@ impl KeyManagementAlgorithm {
     }
 
     /// Decrypt or unwrap a CEK with the provided algorithm
-    pub fn decrypt<'de, T: Serialize + Deserialize<'de>>(&self,
-                                                         encrypted: &EncryptionResult,
-                                                         content_alg: ContentEncryptionAlgorithm,
-                                                         key: &jwk::JWK<T>)
-                                                         -> Result<jwk::JWK<::Empty>, Error> {
+    pub fn decrypt<T: Serialize + for<'de> Deserialize<'de>>(&self,
+                                                             encrypted: &EncryptionResult,
+                                                             content_alg: ContentEncryptionAlgorithm,
+                                                             key: &jwk::JWK<T>)
+                                                             -> Result<jwk::JWK<::Empty>, Error> {
         use self::KeyManagementAlgorithm::*;
 
         match *self {
@@ -423,10 +420,10 @@ impl KeyManagementAlgorithm {
         }
     }
 
-    fn aes_gcm_encrypt<'de, T: Serialize + Deserialize<'de>>(&self,
-                                                             payload: &[u8],
-                                                             key: &jwk::JWK<T>)
-                                                             -> Result<EncryptionResult, Error> {
+    fn aes_gcm_encrypt<T: Serialize + for<'de> Deserialize<'de>>(&self,
+                                                                 payload: &[u8],
+                                                                 key: &jwk::JWK<T>)
+                                                                 -> Result<EncryptionResult, Error> {
         use self::KeyManagementAlgorithm::*;
 
         let algorithm = match *self {
@@ -437,11 +434,11 @@ impl KeyManagementAlgorithm {
         aes_gcm_encrypt(algorithm, payload, &[], key)
     }
 
-    fn aes_gcm_decrypt<'de, T: Serialize + Deserialize<'de>>(&self,
-                                                             encrypted: &EncryptionResult,
-                                                             content_alg: ContentEncryptionAlgorithm,
-                                                             key: &jwk::JWK<T>)
-                                                             -> Result<jwk::JWK<::Empty>, Error> {
+    fn aes_gcm_decrypt<T: Serialize + for<'de> Deserialize<'de>>(&self,
+                                                                 encrypted: &EncryptionResult,
+                                                                 content_alg: ContentEncryptionAlgorithm,
+                                                                 key: &jwk::JWK<T>)
+                                                                 -> Result<jwk::JWK<::Empty>, Error> {
         use self::KeyManagementAlgorithm::*;
 
         let algorithm = match *self {
@@ -483,11 +480,11 @@ impl ContentEncryptionAlgorithm {
     }
 
     /// Encrypt some payload with the provided algorith
-    pub fn encrypt<'de, T: Serialize + Deserialize<'de>>(&self,
-                                                         payload: &[u8],
-                                                         aad: &[u8],
-                                                         key: &jwk::JWK<T>)
-                                                         -> Result<EncryptionResult, Error> {
+    pub fn encrypt<T: Serialize + for<'de> Deserialize<'de>>(&self,
+                                                             payload: &[u8],
+                                                             aad: &[u8],
+                                                             key: &jwk::JWK<T>)
+                                                             -> Result<EncryptionResult, Error> {
         use self::ContentEncryptionAlgorithm::*;
 
         match *self {
@@ -498,10 +495,10 @@ impl ContentEncryptionAlgorithm {
     }
 
     /// Decrypt some payload with the provided algorith,
-    pub fn decrypt<'de, T: Serialize + Deserialize<'de>>(&self,
-                                                         encrypted: &EncryptionResult,
-                                                         key: &jwk::JWK<T>)
-                                                         -> Result<Vec<u8>, Error> {
+    pub fn decrypt<T: Serialize + for<'de> Deserialize<'de>>(&self,
+                                                             encrypted: &EncryptionResult,
+                                                             key: &jwk::JWK<T>)
+                                                             -> Result<Vec<u8>, Error> {
         use self::ContentEncryptionAlgorithm::*;
 
         match *self {
@@ -510,11 +507,11 @@ impl ContentEncryptionAlgorithm {
         }
     }
 
-    fn aes_gcm_encrypt<'de, T: Serialize + Deserialize<'de>>(&self,
-                                                             payload: &[u8],
-                                                             aad: &[u8],
-                                                             key: &jwk::JWK<T>)
-                                                             -> Result<EncryptionResult, Error> {
+    fn aes_gcm_encrypt<T: Serialize + for<'de> Deserialize<'de>>(&self,
+                                                                 payload: &[u8],
+                                                                 aad: &[u8],
+                                                                 key: &jwk::JWK<T>)
+                                                                 -> Result<EncryptionResult, Error> {
         use self::ContentEncryptionAlgorithm::*;
 
         let algorithm = match *self {
@@ -525,10 +522,10 @@ impl ContentEncryptionAlgorithm {
         aes_gcm_encrypt(algorithm, payload, aad, key)
     }
 
-    fn aes_gcm_decrypt<'de, T: Serialize + Deserialize<'de>>(&self,
-                                                             encrypted: &EncryptionResult,
-                                                             key: &jwk::JWK<T>)
-                                                             -> Result<Vec<u8>, Error> {
+    fn aes_gcm_decrypt<T: Serialize + for<'de> Deserialize<'de>>(&self,
+                                                                 encrypted: &EncryptionResult,
+                                                                 key: &jwk::JWK<T>)
+                                                                 -> Result<Vec<u8>, Error> {
         use self::ContentEncryptionAlgorithm::*;
 
         let algorithm = match *self {
@@ -553,11 +550,11 @@ pub fn rng() -> &'static SystemRandom {
 }
 
 /// Encrypt a payload with AES GCM
-fn aes_gcm_encrypt<'de, T: Serialize + Deserialize<'de>>(algorithm: &'static aead::Algorithm,
-                                                         payload: &[u8],
-                                                         aad: &[u8],
-                                                         key: &jwk::JWK<T>)
-                                                         -> Result<EncryptionResult, Error> {
+fn aes_gcm_encrypt<T: Serialize + for<'de> Deserialize<'de>>(algorithm: &'static aead::Algorithm,
+                                                             payload: &[u8],
+                                                             aad: &[u8],
+                                                             key: &jwk::JWK<T>)
+                                                             -> Result<EncryptionResult, Error> {
 
     // JWA needs a 128 bit tag length. We need to assert that the algorithm has 128 bit tag length
     assert_eq!(algorithm.tag_len(), TAG_SIZE);
@@ -583,10 +580,10 @@ fn aes_gcm_encrypt<'de, T: Serialize + Deserialize<'de>>(algorithm: &'static aea
 }
 
 /// Decrypts a payload with AES GCM
-fn aes_gcm_decrypt<'de, T: Serialize + Deserialize<'de>>(algorithm: &'static aead::Algorithm,
-                                                         encrypted: &EncryptionResult,
-                                                         key: &jwk::JWK<T>)
-                                                         -> Result<Vec<u8>, Error> {
+fn aes_gcm_decrypt<T: Serialize + for<'de> Deserialize<'de>>(algorithm: &'static aead::Algorithm,
+                                                             encrypted: &EncryptionResult,
+                                                             key: &jwk::JWK<T>)
+                                                             -> Result<Vec<u8>, Error> {
     // JWA needs a 128 bit tag length. We need to assert that the algorithm has 128 bit tag length
     assert_eq!(algorithm.tag_len(), TAG_SIZE);
     // Also the nonce (or initialization vector) needs to be 96 bits

--- a/src/jwa.rs
+++ b/src/jwa.rs
@@ -354,8 +354,11 @@ impl KeyManagementAlgorithm {
     }
 
     /// Retrieve the Content Encryption Key (CEK) based on the algorithm for encryption
-    pub fn cek<T>(&self, content_alg: ContentEncryptionAlgorithm, key: &jwk::JWK<T>) -> Result<jwk::JWK<::Empty>, Error>
-        where T: Serialize + Deserialize
+    pub fn cek<'de, T>(&self,
+                       content_alg: ContentEncryptionAlgorithm,
+                       key: &jwk::JWK<T>)
+                       -> Result<jwk::JWK<::Empty>, Error>
+        where T: Serialize + Deserialize<'de>
     {
         use self::KeyManagementAlgorithm::*;
 
@@ -366,8 +369,8 @@ impl KeyManagementAlgorithm {
         }
     }
 
-    fn cek_direct<T>(&self, key: &jwk::JWK<T>) -> Result<jwk::JWK<::Empty>, Error>
-        where T: Serialize + Deserialize
+    fn cek_direct<'de, T>(&self, key: &jwk::JWK<T>) -> Result<jwk::JWK<::Empty>, Error>
+        where T: Serialize + Deserialize<'de>
     {
         match key.key_type() {
             jwk::KeyType::Octect => Ok(key.clone_without_additional()),
@@ -392,10 +395,10 @@ impl KeyManagementAlgorithm {
     }
 
     /// Encrypt or wrap a key with the provided algorithm
-    pub fn encrypt<T: Serialize + Deserialize>(&self,
-                                               payload: &[u8],
-                                               key: &jwk::JWK<T>)
-                                               -> Result<EncryptionResult, Error> {
+    pub fn encrypt<'de, T: Serialize + Deserialize<'de>>(&self,
+                                                         payload: &[u8],
+                                                         key: &jwk::JWK<T>)
+                                                         -> Result<EncryptionResult, Error> {
         use self::KeyManagementAlgorithm::*;
 
         match *self {
@@ -406,11 +409,11 @@ impl KeyManagementAlgorithm {
     }
 
     /// Decrypt or unwrap a CEK with the provided algorithm
-    pub fn decrypt<T: Serialize + Deserialize>(&self,
-                                               encrypted: &EncryptionResult,
-                                               content_alg: ContentEncryptionAlgorithm,
-                                               key: &jwk::JWK<T>)
-                                               -> Result<jwk::JWK<::Empty>, Error> {
+    pub fn decrypt<'de, T: Serialize + Deserialize<'de>>(&self,
+                                                         encrypted: &EncryptionResult,
+                                                         content_alg: ContentEncryptionAlgorithm,
+                                                         key: &jwk::JWK<T>)
+                                                         -> Result<jwk::JWK<::Empty>, Error> {
         use self::KeyManagementAlgorithm::*;
 
         match *self {
@@ -420,10 +423,10 @@ impl KeyManagementAlgorithm {
         }
     }
 
-    fn aes_gcm_encrypt<T: Serialize + Deserialize>(&self,
-                                                   payload: &[u8],
-                                                   key: &jwk::JWK<T>)
-                                                   -> Result<EncryptionResult, Error> {
+    fn aes_gcm_encrypt<'de, T: Serialize + Deserialize<'de>>(&self,
+                                                             payload: &[u8],
+                                                             key: &jwk::JWK<T>)
+                                                             -> Result<EncryptionResult, Error> {
         use self::KeyManagementAlgorithm::*;
 
         let algorithm = match *self {
@@ -434,11 +437,11 @@ impl KeyManagementAlgorithm {
         aes_gcm_encrypt(algorithm, payload, &[], key)
     }
 
-    fn aes_gcm_decrypt<T: Serialize + Deserialize>(&self,
-                                                   encrypted: &EncryptionResult,
-                                                   content_alg: ContentEncryptionAlgorithm,
-                                                   key: &jwk::JWK<T>)
-                                                   -> Result<jwk::JWK<::Empty>, Error> {
+    fn aes_gcm_decrypt<'de, T: Serialize + Deserialize<'de>>(&self,
+                                                             encrypted: &EncryptionResult,
+                                                             content_alg: ContentEncryptionAlgorithm,
+                                                             key: &jwk::JWK<T>)
+                                                             -> Result<jwk::JWK<::Empty>, Error> {
         use self::KeyManagementAlgorithm::*;
 
         let algorithm = match *self {
@@ -480,11 +483,11 @@ impl ContentEncryptionAlgorithm {
     }
 
     /// Encrypt some payload with the provided algorith
-    pub fn encrypt<T: Serialize + Deserialize>(&self,
-                                               payload: &[u8],
-                                               aad: &[u8],
-                                               key: &jwk::JWK<T>)
-                                               -> Result<EncryptionResult, Error> {
+    pub fn encrypt<'de, T: Serialize + Deserialize<'de>>(&self,
+                                                         payload: &[u8],
+                                                         aad: &[u8],
+                                                         key: &jwk::JWK<T>)
+                                                         -> Result<EncryptionResult, Error> {
         use self::ContentEncryptionAlgorithm::*;
 
         match *self {
@@ -495,10 +498,10 @@ impl ContentEncryptionAlgorithm {
     }
 
     /// Decrypt some payload with the provided algorith,
-    pub fn decrypt<T: Serialize + Deserialize>(&self,
-                                               encrypted: &EncryptionResult,
-                                               key: &jwk::JWK<T>)
-                                               -> Result<Vec<u8>, Error> {
+    pub fn decrypt<'de, T: Serialize + Deserialize<'de>>(&self,
+                                                         encrypted: &EncryptionResult,
+                                                         key: &jwk::JWK<T>)
+                                                         -> Result<Vec<u8>, Error> {
         use self::ContentEncryptionAlgorithm::*;
 
         match *self {
@@ -507,11 +510,11 @@ impl ContentEncryptionAlgorithm {
         }
     }
 
-    fn aes_gcm_encrypt<T: Serialize + Deserialize>(&self,
-                                                   payload: &[u8],
-                                                   aad: &[u8],
-                                                   key: &jwk::JWK<T>)
-                                                   -> Result<EncryptionResult, Error> {
+    fn aes_gcm_encrypt<'de, T: Serialize + Deserialize<'de>>(&self,
+                                                             payload: &[u8],
+                                                             aad: &[u8],
+                                                             key: &jwk::JWK<T>)
+                                                             -> Result<EncryptionResult, Error> {
         use self::ContentEncryptionAlgorithm::*;
 
         let algorithm = match *self {
@@ -522,10 +525,10 @@ impl ContentEncryptionAlgorithm {
         aes_gcm_encrypt(algorithm, payload, aad, key)
     }
 
-    fn aes_gcm_decrypt<T: Serialize + Deserialize>(&self,
-                                                   encrypted: &EncryptionResult,
-                                                   key: &jwk::JWK<T>)
-                                                   -> Result<Vec<u8>, Error> {
+    fn aes_gcm_decrypt<'de, T: Serialize + Deserialize<'de>>(&self,
+                                                             encrypted: &EncryptionResult,
+                                                             key: &jwk::JWK<T>)
+                                                             -> Result<Vec<u8>, Error> {
         use self::ContentEncryptionAlgorithm::*;
 
         let algorithm = match *self {
@@ -550,11 +553,11 @@ pub fn rng() -> &'static SystemRandom {
 }
 
 /// Encrypt a payload with AES GCM
-fn aes_gcm_encrypt<T: Serialize + Deserialize>(algorithm: &'static aead::Algorithm,
-                                               payload: &[u8],
-                                               aad: &[u8],
-                                               key: &jwk::JWK<T>)
-                                               -> Result<EncryptionResult, Error> {
+fn aes_gcm_encrypt<'de, T: Serialize + Deserialize<'de>>(algorithm: &'static aead::Algorithm,
+                                                         payload: &[u8],
+                                                         aad: &[u8],
+                                                         key: &jwk::JWK<T>)
+                                                         -> Result<EncryptionResult, Error> {
 
     // JWA needs a 128 bit tag length. We need to assert that the algorithm has 128 bit tag length
     assert_eq!(algorithm.tag_len(), TAG_SIZE);
@@ -580,10 +583,10 @@ fn aes_gcm_encrypt<T: Serialize + Deserialize>(algorithm: &'static aead::Algorit
 }
 
 /// Decrypts a payload with AES GCM
-fn aes_gcm_decrypt<T: Serialize + Deserialize>(algorithm: &'static aead::Algorithm,
-                                               encrypted: &EncryptionResult,
-                                               key: &jwk::JWK<T>)
-                                               -> Result<Vec<u8>, Error> {
+fn aes_gcm_decrypt<'de, T: Serialize + Deserialize<'de>>(algorithm: &'static aead::Algorithm,
+                                                         encrypted: &EncryptionResult,
+                                                         key: &jwk::JWK<T>)
+                                                         -> Result<Vec<u8>, Error> {
     // JWA needs a 128 bit tag length. We need to assert that the algorithm has 128 bit tag length
     assert_eq!(algorithm.tag_len(), TAG_SIZE);
     // Also the nonce (or initialization vector) needs to be 96 bits

--- a/src/jwe.rs
+++ b/src/jwe.rs
@@ -165,7 +165,7 @@ pub struct CekAlgorithmHeader {
 
 /// JWE Header, consisting of the registered fields and other custom fields
 #[derive(Debug, Eq, PartialEq, Clone, Default)]
-pub struct Header<T: Serialize + Deserialize> {
+pub struct Header<T: Serialize + for<'de_inner> Deserialize<'de_inner>> {
     /// Registered header fields
     pub registered: RegisteredHeader,
     /// Key management algorithm specific headers
@@ -177,9 +177,9 @@ pub struct Header<T: Serialize + Deserialize> {
 impl_flatten_serde_generic!(Header<T>, serde_custom::flatten::DuplicateKeysBehaviour::RaiseError,
                             registered, cek_algorithm, private);
 
-impl<T: Serialize + Deserialize + 'static> CompactJson for Header<T> {}
+impl<T: Serialize + for<'de_inner> Deserialize<'de_inner>> CompactJson for Header<T> {}
 
-impl<T: Serialize + Deserialize + 'static> Header<T> {
+impl<T: Serialize + for<'de_inner> Deserialize<'de_inner>> Header<T> {
     /// Update CEK algorithm specific header fields based on a CEK encryption result
     fn update_cek_algorithm(&mut self, encrypted: &EncryptionResult) {
         if !encrypted.nonce.is_empty() {
@@ -274,13 +274,14 @@ impl From<RegisteredHeader> for Header<Empty> {
 /// # }
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum Compact<T: CompactPart, H: Serialize + Deserialize + Clone + 'static> {
+pub enum Compact<T: CompactPart, H: Serialize + for<'de_inner> Deserialize<'de_inner> + Clone> {
     /// Decrypted form of the JWE.
     /// This variant cannot be serialized or deserialized and will return an error.
     #[serde(skip_serializing)]
     #[serde(skip_deserializing)]
     Decrypted {
         /// Embedded header
+        #[serde(bound(deserialize = ""))]
         header: Header<H>,
         /// Payload, usually a signed/unsigned JWT
         payload: T,
@@ -289,7 +290,7 @@ pub enum Compact<T: CompactPart, H: Serialize + Deserialize + Clone + 'static> {
     Encrypted(::Compact),
 }
 
-impl<T: CompactPart, H: Serialize + Deserialize + Clone + 'static> Compact<T, H> {
+impl<T: CompactPart, H: Serialize + for<'de_inner> Deserialize<'de_inner> + Clone> Compact<T, H> {
     /// Create a new encrypted JWE
     pub fn new_decrypted(header: Header<H>, payload: T) -> Self {
         Compact::Decrypted {
@@ -305,7 +306,9 @@ impl<T: CompactPart, H: Serialize + Deserialize + Clone + 'static> Compact<T, H>
 
     /// Consumes self and encrypt it. If the token is already encrypted,
     /// this is a no-op.
-    pub fn into_encrypted<'de_k, K: Serialize + Deserialize<'de_k>>(self, key: &jwk::JWK<K>) -> Result<Self, Error> {
+    pub fn into_encrypted<K: Serialize + for<'de_key> Deserialize<'de_key>>(self,
+                                                                            key: &jwk::JWK<K>)
+                                                                            -> Result<Self, Error> {
         match self {
             Compact::Encrypted(_) => Ok(self),
             Compact::Decrypted { .. } => self.encrypt(key),
@@ -313,7 +316,7 @@ impl<T: CompactPart, H: Serialize + Deserialize + Clone + 'static> Compact<T, H>
     }
 
     /// Encrypt an Decrypted JWE
-    pub fn encrypt<'de_k, K: Serialize + Deserialize<'de_k>>(&self, key: &jwk::JWK<K>) -> Result<Self, Error> {
+    pub fn encrypt<K: Serialize + for<'de_key> Deserialize<'de_key>>(&self, key: &jwk::JWK<K>) -> Result<Self, Error> {
         match *self {
             Compact::Encrypted(_) => Err(Error::UnsupportedOperation),
             Compact::Decrypted {
@@ -366,11 +369,11 @@ impl<T: CompactPart, H: Serialize + Deserialize + Clone + 'static> Compact<T, H>
 
     /// Consumes self and decrypt it. If the token is already decrypted,
     /// this is a no-op.
-    pub fn into_decrypted<'de_k, K: Serialize + Deserialize<'de_k>>(self,
-                                                                    key: &jwk::JWK<K>,
-                                                                    cek_alg: KeyManagementAlgorithm,
-                                                                    enc_alg: ContentEncryptionAlgorithm)
-                                                                    -> Result<Self, Error> {
+    pub fn into_decrypted<K: Serialize + for<'de_key> Deserialize<'de_key>>(self,
+                                                                            key: &jwk::JWK<K>,
+                                                                            cek_alg: KeyManagementAlgorithm,
+                                                                            enc_alg: ContentEncryptionAlgorithm)
+                                                                            -> Result<Self, Error> {
         match self {
             Compact::Encrypted(_) => self.decrypt(key, cek_alg, enc_alg),
             Compact::Decrypted { .. } => Ok(self),
@@ -379,11 +382,11 @@ impl<T: CompactPart, H: Serialize + Deserialize + Clone + 'static> Compact<T, H>
 
     /// Decrypt an encrypted JWE. Provide the expected algorithms to mitigate an attacker modifying the
     /// fields
-    pub fn decrypt<'de_k, K: Serialize + Deserialize<'de_k>>(&self,
-                                                             key: &jwk::JWK<K>,
-                                                             cek_alg: KeyManagementAlgorithm,
-                                                             enc_alg: ContentEncryptionAlgorithm)
-                                                             -> Result<Self, Error> {
+    pub fn decrypt<K: Serialize + for<'de_key> Deserialize<'de_key>>(&self,
+                                                                     key: &jwk::JWK<K>,
+                                                                     cek_alg: KeyManagementAlgorithm,
+                                                                     enc_alg: ContentEncryptionAlgorithm)
+                                                                     -> Result<Self, Error> {
         match *self {
             Compact::Encrypted(ref encrypted) => {
                 if encrypted.len() != 5 {

--- a/src/jwe.rs
+++ b/src/jwe.rs
@@ -305,7 +305,7 @@ impl<T: CompactPart, H: Serialize + Deserialize + Clone + 'static> Compact<T, H>
 
     /// Consumes self and encrypt it. If the token is already encrypted,
     /// this is a no-op.
-    pub fn into_encrypted<K: Serialize + Deserialize>(self, key: &jwk::JWK<K>) -> Result<Self, Error> {
+    pub fn into_encrypted<'de_k, K: Serialize + Deserialize<'de_k>>(self, key: &jwk::JWK<K>) -> Result<Self, Error> {
         match self {
             Compact::Encrypted(_) => Ok(self),
             Compact::Decrypted { .. } => self.encrypt(key),
@@ -313,7 +313,7 @@ impl<T: CompactPart, H: Serialize + Deserialize + Clone + 'static> Compact<T, H>
     }
 
     /// Encrypt an Decrypted JWE
-    pub fn encrypt<K: Serialize + Deserialize>(&self, key: &jwk::JWK<K>) -> Result<Self, Error> {
+    pub fn encrypt<'de_k, K: Serialize + Deserialize<'de_k>>(&self, key: &jwk::JWK<K>) -> Result<Self, Error> {
         match *self {
             Compact::Encrypted(_) => Err(Error::UnsupportedOperation),
             Compact::Decrypted {
@@ -366,11 +366,11 @@ impl<T: CompactPart, H: Serialize + Deserialize + Clone + 'static> Compact<T, H>
 
     /// Consumes self and decrypt it. If the token is already decrypted,
     /// this is a no-op.
-    pub fn into_decrypted<K: Serialize + Deserialize>(self,
-                                                      key: &jwk::JWK<K>,
-                                                      cek_alg: KeyManagementAlgorithm,
-                                                      enc_alg: ContentEncryptionAlgorithm)
-                                                      -> Result<Self, Error> {
+    pub fn into_decrypted<'de_k, K: Serialize + Deserialize<'de_k>>(self,
+                                                                    key: &jwk::JWK<K>,
+                                                                    cek_alg: KeyManagementAlgorithm,
+                                                                    enc_alg: ContentEncryptionAlgorithm)
+                                                                    -> Result<Self, Error> {
         match self {
             Compact::Encrypted(_) => self.decrypt(key, cek_alg, enc_alg),
             Compact::Decrypted { .. } => Ok(self),
@@ -379,11 +379,11 @@ impl<T: CompactPart, H: Serialize + Deserialize + Clone + 'static> Compact<T, H>
 
     /// Decrypt an encrypted JWE. Provide the expected algorithms to mitigate an attacker modifying the
     /// fields
-    pub fn decrypt<K: Serialize + Deserialize>(&self,
-                                               key: &jwk::JWK<K>,
-                                               cek_alg: KeyManagementAlgorithm,
-                                               enc_alg: ContentEncryptionAlgorithm)
-                                               -> Result<Self, Error> {
+    pub fn decrypt<'de_k, K: Serialize + Deserialize<'de_k>>(&self,
+                                                             key: &jwk::JWK<K>,
+                                                             cek_alg: KeyManagementAlgorithm,
+                                                             enc_alg: ContentEncryptionAlgorithm)
+                                                             -> Result<Self, Error> {
         match *self {
             Compact::Encrypted(ref encrypted) => {
                 if encrypted.len() != 5 {

--- a/src/jwe.rs
+++ b/src/jwe.rs
@@ -36,13 +36,13 @@ impl Serialize for CompressionAlgorithm {
     }
 }
 
-impl Deserialize for CompressionAlgorithm {
+impl<'de> Deserialize<'de> for CompressionAlgorithm {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: Deserializer
+        where D: Deserializer<'de>
     {
 
         struct CompressionAlgorithmVisitor;
-        impl de::Visitor for CompressionAlgorithmVisitor {
+        impl<'de> de::Visitor<'de> for CompressionAlgorithmVisitor {
             type Value = CompressionAlgorithm;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/src/jwe.rs
+++ b/src/jwe.rs
@@ -535,16 +535,20 @@ mod tests {
 
         let test_value = Test { test: CompressionAlgorithm::Deflate };
         assert_tokens(&test_value,
-                      &[Token::StructStart("Test", 1),
-                        Token::StructSep,
+                      &[Token::Struct {
+                            name: "Test",
+                            len: 1,
+                        },
                         Token::Str("test"),
                         Token::Str("DEF"),
                         Token::StructEnd]);
 
         let test_value = Test { test: CompressionAlgorithm::Other("xxx".to_string()) };
         assert_tokens(&test_value,
-                      &[Token::StructStart("Test", 1),
-                        Token::StructSep,
+                      &[Token::Struct {
+                            name: "Test",
+                            len: 1,
+                        },
                         Token::Str("test"),
                         Token::Str("xxx"),
                         Token::StructEnd]);

--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -526,24 +526,30 @@ mod tests {
 
         let test_value = Test { test: PublicKeyUse::Encryption };
         assert_tokens(&test_value,
-                      &[Token::StructStart("Test", 1),
-                        Token::StructSep,
+                      &[Token::Struct {
+                            name: "Test",
+                            len: 1,
+                        },
                         Token::Str("test"),
                         Token::Str("enc"),
                         Token::StructEnd]);
 
         let test_value = Test { test: PublicKeyUse::Encryption };
         assert_tokens(&test_value,
-                      &[Token::StructStart("Test", 1),
-                        Token::StructSep,
+                      &[Token::Struct {
+                            name: "Test",
+                            len: 1,
+                        },
                         Token::Str("test"),
                         Token::Str("enc"),
                         Token::StructEnd]);
 
         let test_value = Test { test: PublicKeyUse::Other("xxx".to_string()) };
         assert_tokens(&test_value,
-                      &[Token::StructStart("Test", 1),
-                        Token::StructSep,
+                      &[Token::Struct {
+                            name: "Test",
+                            len: 1,
+                        },
                         Token::Str("test"),
                         Token::Str("xxx"),
                         Token::StructEnd]);
@@ -576,16 +582,20 @@ mod tests {
 
         let test_value = Test { test: KeyOperations::Sign };
         assert_tokens(&test_value,
-                      &[Token::StructStart("Test", 1),
-                        Token::StructSep,
+                      &[Token::Struct {
+                            name: "Test",
+                            len: 1,
+                        },
                         Token::Str("test"),
                         Token::Str("sign"),
                         Token::StructEnd]);
 
         let test_value = Test { test: KeyOperations::Verify };
         assert_tokens(&test_value,
-                      &[Token::StructStart("Test", 1),
-                        Token::StructSep,
+                      &[Token::Struct {
+                            name: "Test",
+                            len: 1,
+                        },
                         Token::Str("test"),
                         Token::Str("verify"),
                         Token::StructEnd]);
@@ -593,56 +603,70 @@ mod tests {
 
         let test_value = Test { test: KeyOperations::Encrypt };
         assert_tokens(&test_value,
-                      &[Token::StructStart("Test", 1),
-                        Token::StructSep,
+                      &[Token::Struct {
+                            name: "Test",
+                            len: 1,
+                        },
                         Token::Str("test"),
                         Token::Str("encrypt"),
                         Token::StructEnd]);
 
         let test_value = Test { test: KeyOperations::Decrypt };
         assert_tokens(&test_value,
-                      &[Token::StructStart("Test", 1),
-                        Token::StructSep,
+                      &[Token::Struct {
+                            name: "Test",
+                            len: 1,
+                        },
                         Token::Str("test"),
                         Token::Str("decrypt"),
                         Token::StructEnd]);
 
         let test_value = Test { test: KeyOperations::WrapKey };
         assert_tokens(&test_value,
-                      &[Token::StructStart("Test", 1),
-                        Token::StructSep,
+                      &[Token::Struct {
+                            name: "Test",
+                            len: 1,
+                        },
                         Token::Str("test"),
                         Token::Str("wrapKey"),
                         Token::StructEnd]);
 
         let test_value = Test { test: KeyOperations::UnwrapKey };
         assert_tokens(&test_value,
-                      &[Token::StructStart("Test", 1),
-                        Token::StructSep,
+                      &[Token::Struct {
+                            name: "Test",
+                            len: 1,
+                        },
                         Token::Str("test"),
                         Token::Str("unwrapKey"),
                         Token::StructEnd]);
 
         let test_value = Test { test: KeyOperations::DeriveKey };
         assert_tokens(&test_value,
-                      &[Token::StructStart("Test", 1),
-                        Token::StructSep,
+                      &[Token::Struct {
+                            name: "Test",
+                            len: 1,
+                        },
                         Token::Str("test"),
                         Token::Str("deriveKey"),
                         Token::StructEnd]);
 
         let test_value = Test { test: KeyOperations::DeriveBits };
         assert_tokens(&test_value,
-                      &[Token::StructStart("Test", 1),
-                        Token::StructSep,
+                      &[Token::Struct {
+                            name: "Test",
+                            len: 1,
+                        },
                         Token::Str("test"),
                         Token::Str("deriveBits"),
                         Token::StructEnd]);
 
         let test_value = Test { test: KeyOperations::Other("xxx".to_string()) };
         assert_tokens(&test_value,
-                      &[Token::StructStart("Test", 1),
-                        Token::StructSep,
+                      &[Token::Struct {
+                            name: "Test",
+                            len: 1,
+                        },
                         Token::Str("test"),
                         Token::Str("xxx"),
                         Token::StructEnd]);

--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -67,13 +67,13 @@ impl Serialize for PublicKeyUse {
     }
 }
 
-impl Deserialize for PublicKeyUse {
+impl<'de> Deserialize<'de> for PublicKeyUse {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: Deserializer
+        where D: Deserializer<'de>
     {
 
         struct PublicKeyUseVisitor;
-        impl de::Visitor for PublicKeyUseVisitor {
+        impl<'de> de::Visitor<'de> for PublicKeyUseVisitor {
             type Value = PublicKeyUse;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -139,13 +139,13 @@ impl Serialize for KeyOperations {
     }
 }
 
-impl Deserialize for KeyOperations {
+impl<'de> Deserialize<'de> for KeyOperations {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: Deserializer
+        where D: Deserializer<'de>
     {
 
         struct KeyOperationsVisitor;
-        impl de::Visitor for KeyOperationsVisitor {
+        impl<'de> de::Visitor<'de> for KeyOperationsVisitor {
             type Value = KeyOperations;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -454,7 +454,7 @@ impl Default for EllipticCurve {
 /// The members of the object represent properties of the key, including its value.
 /// Type `T` is a struct representing additional JWK properties
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct JWK<T: Serialize + Deserialize + 'static> {
+pub struct JWK<T: Serialize + for<'de_inner> Deserialize<'de_inner>> {
     /// Common JWK parameters
     pub common: CommonParameters,
     /// Key algorithm specific parameters
@@ -466,7 +466,7 @@ pub struct JWK<T: Serialize + Deserialize + 'static> {
 impl_flatten_serde_generic!(JWK<T>, serde_custom::flatten::DuplicateKeysBehaviour::RaiseError,
                             common, algorithm, additional);
 
-impl<T: Serialize + Deserialize + 'static> JWK<T> {
+impl<T: Serialize + for<'de_inner> Deserialize<'de_inner>> JWK<T> {
     /// Convenience to create a new bare-bones Octect key
     pub fn new_octect_key(key: &[u8], additional: T) -> Self {
         Self {
@@ -501,8 +501,9 @@ impl<T: Serialize + Deserialize + 'static> JWK<T> {
 
 /// A JSON object that represents a set of JWKs.
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct JWKSet<T: Serialize + Deserialize + 'static> {
+pub struct JWKSet<T: Serialize + for<'de_inner> Deserialize<'de_inner>> {
     /// Containted JWKs
+    #[serde(bound(deserialize = ""))]
     keys: Vec<JWK<T>>,
 }
 

--- a/src/jws.rs
+++ b/src/jws.rs
@@ -94,13 +94,14 @@ use serde_custom;
 /// ```
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum Compact<T: CompactPart, H: Serialize + Deserialize> {
+pub enum Compact<T: CompactPart, H: Serialize + for<'de_inner> Deserialize<'de_inner>> {
     /// Decoded form of the JWS.
     /// This variant cannot be serialized or deserialized and will return an error.
     #[serde(skip_serializing)]
     #[serde(skip_deserializing)]
     Decoded {
         /// Embedded header
+        #[serde(bound(deserialize = ""))]
         header: Header<H>,
         /// Payload, usually a claims set
         payload: T,
@@ -109,7 +110,7 @@ pub enum Compact<T: CompactPart, H: Serialize + Deserialize> {
     Encoded(::Compact),
 }
 
-impl<T: CompactPart, H: Serialize + Deserialize> Compact<T, H> {
+impl<T: CompactPart, H: Serialize + for<'de_inner> Deserialize<'de_inner>> Compact<T, H> {
     /// New decoded JWT
     pub fn new_decoded(header: Header<H>, payload: T) -> Self {
         Compact::Decoded {
@@ -271,7 +272,7 @@ impl<T: CompactPart, H: Serialize + Deserialize> Compact<T, H> {
 
 /// Implementation for embedded inside a JWE.
 // FIXME: Maybe use a separate trait instead?
-impl<T: CompactPart, H: Serialize + Deserialize> CompactPart for Compact<T, H> {
+impl<T: CompactPart, H: Serialize + for<'de_inner> Deserialize<'de_inner>> CompactPart for Compact<T, H> {
     fn to_bytes(&self) -> Result<Vec<u8>, Error> {
         let encoded = self.encoded()?;
         Ok(encoded.to_string().into_bytes())
@@ -390,7 +391,7 @@ impl Secret {
 
 /// JWS Header, consisting of the registered fields and other custom fields
 #[derive(Debug, Eq, PartialEq, Clone, Default)]
-pub struct Header<T: Serialize + Deserialize> {
+pub struct Header<T: Serialize + for<'de_inner> Deserialize<'de_inner>> {
     /// Registered header fields
     pub registered: RegisteredHeader,
     /// Private header fields
@@ -400,7 +401,7 @@ pub struct Header<T: Serialize + Deserialize> {
 impl_flatten_serde_generic!(Header<T>, serde_custom::flatten::DuplicateKeysBehaviour::RaiseError,
                             registered, private);
 
-impl<T: Serialize + Deserialize> CompactJson for Header<T> {}
+impl<T: Serialize + for<'de_inner> Deserialize<'de_inner>> CompactJson for Header<T> {}
 
 impl Header<Empty> {
     /// Convenience function to create a header with only registered headers

--- a/src/jws.rs
+++ b/src/jws.rs
@@ -94,7 +94,7 @@ use serde_custom;
 /// ```
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum Compact<T: CompactPart, H: Serialize + Deserialize + 'static> {
+pub enum Compact<T: CompactPart, H: Serialize + Deserialize> {
     /// Decoded form of the JWS.
     /// This variant cannot be serialized or deserialized and will return an error.
     #[serde(skip_serializing)]
@@ -109,7 +109,7 @@ pub enum Compact<T: CompactPart, H: Serialize + Deserialize + 'static> {
     Encoded(::Compact),
 }
 
-impl<T: CompactPart, H: Serialize + Deserialize + 'static> Compact<T, H> {
+impl<T: CompactPart, H: Serialize + Deserialize> Compact<T, H> {
     /// New decoded JWT
     pub fn new_decoded(header: Header<H>, payload: T) -> Self {
         Compact::Decoded {
@@ -271,7 +271,7 @@ impl<T: CompactPart, H: Serialize + Deserialize + 'static> Compact<T, H> {
 
 /// Implementation for embedded inside a JWE.
 // FIXME: Maybe use a separate trait instead?
-impl<T: CompactPart, H: Serialize + Deserialize + 'static> CompactPart for Compact<T, H> {
+impl<T: CompactPart, H: Serialize + Deserialize> CompactPart for Compact<T, H> {
     fn to_bytes(&self) -> Result<Vec<u8>, Error> {
         let encoded = self.encoded()?;
         Ok(encoded.to_string().into_bytes())
@@ -400,7 +400,7 @@ pub struct Header<T: Serialize + Deserialize> {
 impl_flatten_serde_generic!(Header<T>, serde_custom::flatten::DuplicateKeysBehaviour::RaiseError,
                             registered, private);
 
-impl<T: Serialize + Deserialize + 'static> CompactJson for Header<T> {}
+impl<T: Serialize + Deserialize> CompactJson for Header<T> {}
 
 impl Header<Empty> {
     /// Convenience function to create a header with only registered headers

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,7 +328,7 @@ pub trait CompactPart {
 /// A marker trait that indicates that the object is to be serialized to JSON and deserialized from JSON.
 /// This is primarily used in conjunction with the `CompactPart` trait which will serialize structs to JSON before
 /// base64 encoding, and vice-versa.
-pub trait CompactJson: Serialize + Deserialize {}
+pub trait CompactJson: Serialize + for<'de> Deserialize<'de> {}
 
 impl<T> CompactPart for T
     where T: CompactJson
@@ -903,7 +903,7 @@ pub struct ClaimsSet<T: Serialize + Deserialize> {
 impl_flatten_serde_generic!(ClaimsSet<T>, serde_custom::flatten::DuplicateKeysBehaviour::RaiseError,
                             registered, private);
 
-impl<T> CompactJson for ClaimsSet<T> where T: Serialize + Deserialize + 'static {}
+impl<T> CompactJson for ClaimsSet<T> where T: Serialize + Deserialize {}
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,7 +328,7 @@ pub trait CompactPart {
 /// A marker trait that indicates that the object is to be serialized to JSON and deserialized from JSON.
 /// This is primarily used in conjunction with the `CompactPart` trait which will serialize structs to JSON before
 /// base64 encoding, and vice-versa.
-pub trait CompactJson: Serialize + for<'de> Deserialize<'de> {}
+pub trait CompactJson: Serialize + for<'de_inner> Deserialize<'de_inner> {}
 
 impl<T> CompactPart for T
     where T: CompactJson
@@ -574,8 +574,9 @@ impl<'de> Deserialize<'de> for Compact {
 /// ```
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
+#[serde(bound(deserialize = ""))]
 pub enum SingleOrMultiple<T>
-    where T: Clone + Debug + Eq + PartialEq + Serialize + Deserialize + Send + Sync
+    where T: Clone + Debug + Eq + PartialEq + Serialize + for<'de_inner> Deserialize<'de_inner> + Send + Sync
 {
     /// One single value
     Single(T),
@@ -584,7 +585,7 @@ pub enum SingleOrMultiple<T>
 }
 
 impl<T> SingleOrMultiple<T>
-    where T: Clone + Debug + Eq + PartialEq + Serialize + Deserialize + Send + Sync
+    where T: Clone + Debug + Eq + PartialEq + Serialize + for<'de_inner> Deserialize<'de_inner> + Send + Sync
 {
     /// Checks whether this enum, regardless of single or multiple value contains `value`.
     pub fn contains<Q: ?Sized>(&self, value: &Q) -> bool
@@ -893,7 +894,7 @@ impl RegisteredClaims {
 /// A collection of claims, both [registered](https://tools.ietf.org/html/rfc7519#section-4.1) and your custom
 /// private claims.
 #[derive(Debug, Eq, PartialEq, Clone, Default)]
-pub struct ClaimsSet<T: Serialize + Deserialize> {
+pub struct ClaimsSet<T: Serialize + for<'de_inner> Deserialize<'de_inner>> {
     /// Registered claims defined by the RFC
     pub registered: RegisteredClaims,
     /// Application specific claims
@@ -903,7 +904,7 @@ pub struct ClaimsSet<T: Serialize + Deserialize> {
 impl_flatten_serde_generic!(ClaimsSet<T>, serde_custom::flatten::DuplicateKeysBehaviour::RaiseError,
                             registered, private);
 
-impl<T> CompactJson for ClaimsSet<T> where T: Serialize + Deserialize {}
+impl<T> CompactJson for ClaimsSet<T> where T: Serialize + for<'de_inner> Deserialize<'de_inner> {}
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -959,8 +959,10 @@ mod tests {
         assert_eq!(deserialized, test);
 
         assert_tokens(&test,
-                      &[Token::StructStart("StringOrUriTest", 1),
-                        Token::StructSep,
+                      &[Token::Struct {
+                            name: "StringOrUriTest",
+                            len: 1,
+                        },
                         Token::Str("string"),
                         Token::Str("Random"),
 
@@ -980,8 +982,10 @@ mod tests {
         assert_eq!(deserialized, test);
 
         assert_tokens(&test,
-                      &[Token::StructStart("StringOrUriTest", 1),
-                        Token::StructSep,
+                      &[Token::Struct {
+                            name: "StringOrUriTest",
+                            len: 1,
+                        },
                         Token::Str("string"),
                         Token::Str("https://www.example.com/"),
 
@@ -1145,28 +1149,23 @@ mod tests {
         };
 
         assert_tokens(&claim,
-                      &[Token::MapStart(Some(6)),
-                        Token::MapSep,
+                      &[Token::Map { len: Some(6) },
+
                         Token::Str("iss"),
                         Token::Str("https://www.acme.com/"),
 
-                        Token::MapSep,
                         Token::Str("sub"),
                         Token::Str("John Doe"),
 
-                        Token::MapSep,
                         Token::Str("aud"),
                         Token::Str("htts://acme-customer.com/"),
 
-                        Token::MapSep,
                         Token::Str("nbf"),
                         Token::I64(-1234),
 
-                        Token::MapSep,
                         Token::Str("company"),
                         Token::Str("ACME"),
 
-                        Token::MapSep,
                         Token::Str("department"),
                         Token::Str("Toilet Cleaning"),
                         Token::MapEnd]);
@@ -1188,9 +1187,7 @@ mod tests {
             },
         };
 
-        assert_ser_tokens_error(&claim,
-                                &[],
-                                serde_test::Error::Message("Structs have duplicate keys".to_string()));
+        assert_ser_tokens_error(&claim, &[], "Structs have duplicate keys");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -502,14 +502,14 @@ impl Serialize for Compact {
     }
 }
 
-impl Deserialize for Compact {
+impl<'de> Deserialize<'de> for Compact {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: Deserializer
+        where D: Deserializer<'de>
     {
 
         struct CompactVisitor;
 
-        impl de::Visitor for CompactVisitor {
+        impl<'de> de::Visitor<'de> for CompactVisitor {
             type Value = Compact;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -685,13 +685,13 @@ impl Serialize for StringOrUri {
     }
 }
 
-impl Deserialize for StringOrUri {
+impl<'de> Deserialize<'de> for StringOrUri {
     fn deserialize<D>(deserializer: D) -> Result<StringOrUri, D::Error>
-        where D: Deserializer
+        where D: Deserializer<'de>
     {
         struct StringOrUriVisitor {}
 
-        impl de::Visitor for StringOrUriVisitor {
+        impl<'de> de::Visitor<'de> for StringOrUriVisitor {
             type Value = StringOrUri;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -755,9 +755,9 @@ impl Serialize for Timestamp {
     }
 }
 
-impl Deserialize for Timestamp {
+impl<'de> Deserialize<'de> for Timestamp {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: Deserializer
+        where D: Deserializer<'de>
     {
         let timestamp = i64::deserialize(deserializer)?;
         Ok(Timestamp(DateTime::<UTC>::from_utc(NaiveDateTime::from_timestamp(timestamp, 0), UTC)))

--- a/src/serde_custom/base64_url_uint.rs
+++ b/src/serde_custom/base64_url_uint.rs
@@ -18,12 +18,12 @@ pub fn serialize<S>(value: &BigUint, serializer: S) -> Result<S::Ok, S::Error>
 }
 
 /// Deserialize a `BigUint` from Base64 URL encoded big endian bytes
-pub fn deserialize<D>(deserializer: D) -> Result<BigUint, D::Error>
-    where D: Deserializer
+pub fn deserialize<'de, D>(deserializer: D) -> Result<BigUint, D::Error>
+    where D: Deserializer<'de>
 {
     struct BigUintVisitor;
 
-    impl de::Visitor for BigUintVisitor {
+    impl<'de> de::Visitor<'de> for BigUintVisitor {
         type Value = BigUint;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/src/serde_custom/base64_url_uint.rs
+++ b/src/serde_custom/base64_url_uint.rs
@@ -59,8 +59,10 @@ mod tests {
         let test_value = TestStruct { bytes: BigUint::from_u64(12345).unwrap() };
 
         assert_tokens(&test_value,
-                      &[Token::StructStart("TestStruct", 1),
-                        Token::StructSep,
+                      &[Token::Struct {
+                            name: "TestStruct",
+                            len: 1,
+                        },
                         Token::Str("bytes"),
                         Token::Str("MDk"),
 

--- a/src/serde_custom/byte_sequence.rs
+++ b/src/serde_custom/byte_sequence.rs
@@ -53,8 +53,10 @@ mod tests {
         let test_value = TestStruct { bytes: "hello world".to_string().into_bytes() };
 
         assert_tokens(&test_value,
-                      &[Token::StructStart("TestStruct", 1),
-                        Token::StructSep,
+                      &[Token::Struct {
+                            name: "TestStruct",
+                            len: 1,
+                        },
                         Token::Str("bytes"),
                         Token::Str("aGVsbG8gd29ybGQ"),
 

--- a/src/serde_custom/byte_sequence.rs
+++ b/src/serde_custom/byte_sequence.rs
@@ -14,12 +14,12 @@ pub fn serialize<S>(value: &[u8], serializer: S) -> Result<S::Ok, S::Error>
 }
 
 /// Deserialize a byte sequence from Base64 URL encoded string
-pub fn deserialize<D>(deserializer: D) -> Result<Vec<u8>, D::Error>
-    where D: Deserializer
+pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+    where D: Deserializer<'de>
 {
     struct BytesVisitor;
 
-    impl de::Visitor for BytesVisitor {
+    impl<'de> de::Visitor<'de> for BytesVisitor {
         type Value = Vec<u8>;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/src/serde_custom/option_base64_url_uint.rs
+++ b/src/serde_custom/option_base64_url_uint.rs
@@ -79,10 +79,12 @@ mod tests {
         let test_value = TestStruct { bytes: Some(BigUint::from_u64(12345).unwrap()) };
 
         assert_tokens(&test_value,
-                      &[Token::StructStart("TestStruct", 1),
-                        Token::StructSep,
+                      &[Token::Struct {
+                            name: "TestStruct",
+                            len: 1,
+                        },
                         Token::Str("bytes"),
-                        Token::Option(true),
+                        Token::Some,
                         Token::Str("MDk"),
 
                         Token::StructEnd]);
@@ -93,10 +95,12 @@ mod tests {
         let test_value = TestStruct { bytes: None };
 
         assert_tokens(&test_value,
-                      &[Token::StructStart("TestStruct", 1),
-                        Token::StructSep,
+                      &[Token::Struct {
+                            name: "TestStruct",
+                            len: 1,
+                        },
                         Token::Str("bytes"),
-                        Token::Option(false),
+                        Token::None,
 
                         Token::StructEnd]);
     }

--- a/src/serde_custom/option_base64_url_uint.rs
+++ b/src/serde_custom/option_base64_url_uint.rs
@@ -23,12 +23,12 @@ pub fn serialize<S>(value: &Option<BigUint>, serializer: S) -> Result<S::Ok, S::
 }
 
 /// Deserialize a `BigUint` from Base64 URL encoded big endian bytes
-pub fn deserialize<D>(deserializer: D) -> Result<Option<BigUint>, D::Error>
-    where D: Deserializer
+pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<BigUint>, D::Error>
+    where D: Deserializer<'de>
 {
     struct BigUintVisitor;
 
-    impl de::Visitor for BigUintVisitor {
+    impl<'de> de::Visitor<'de> for BigUintVisitor {
         type Value = Option<BigUint>;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -43,7 +43,7 @@ pub fn deserialize<D>(deserializer: D) -> Result<Option<BigUint>, D::Error>
         }
 
         fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-            where D: Deserializer
+            where D: Deserializer<'de>
         {
 
             deserializer.deserialize_str(self)

--- a/src/serde_custom/option_byte_sequence.rs
+++ b/src/serde_custom/option_byte_sequence.rs
@@ -19,12 +19,12 @@ pub fn serialize<S>(value: &Option<Vec<u8>>, serializer: S) -> Result<S::Ok, S::
 }
 
 /// Deserialize a byte sequence from Base64 URL encoded string
-pub fn deserialize<D>(deserializer: D) -> Result<Option<Vec<u8>>, D::Error>
-    where D: Deserializer
+pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Vec<u8>>, D::Error>
+    where D: Deserializer<'de>
 {
     struct BytesVisitor;
 
-    impl de::Visitor for BytesVisitor {
+    impl<'de> de::Visitor<'de> for BytesVisitor {
         type Value = Option<Vec<u8>>;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -39,7 +39,7 @@ pub fn deserialize<D>(deserializer: D) -> Result<Option<Vec<u8>>, D::Error>
         }
 
         fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-            where D: Deserializer
+            where D: Deserializer<'de>
         {
 
             deserializer.deserialize_str(self)

--- a/src/serde_custom/option_byte_sequence.rs
+++ b/src/serde_custom/option_byte_sequence.rs
@@ -73,10 +73,12 @@ mod tests {
         let test_value = TestStruct { bytes: Some("hello world".to_string().into_bytes()) };
 
         assert_tokens(&test_value,
-                      &[Token::StructStart("TestStruct", 1),
-                        Token::StructSep,
+                      &[Token::Struct {
+                            name: "TestStruct",
+                            len: 1,
+                        },
                         Token::Str("bytes"),
-                        Token::Option(true),
+                        Token::Some,
                         Token::Str("aGVsbG8gd29ybGQ"),
 
                         Token::StructEnd]);
@@ -87,10 +89,12 @@ mod tests {
         let test_value = TestStruct { bytes: None };
 
         assert_tokens(&test_value,
-                      &[Token::StructStart("TestStruct", 1),
-                        Token::StructSep,
+                      &[Token::Struct {
+                            name: "TestStruct",
+                            len: 1,
+                        },
                         Token::Str("bytes"),
-                        Token::Option(false),
+                        Token::None,
 
                         Token::StructEnd]);
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -21,7 +21,7 @@ macro_rules! assert_matches {
 /// is equal to the provided `value`.
 /// If `expected_json` is provided, it will be deserialized to `T` and checked for equality with `value`.
 pub fn assert_serde_json<T>(value: &T, expected_json: Option<&str>)
-    where T: Serialize + Deserialize + Debug + PartialEq
+    where T: Serialize + for<'de> Deserialize<'de> + Debug + PartialEq
 {
     let serialized = not_err!(serde_json::to_string_pretty(value));
     let deserialized: T = not_err!(serde_json::from_str(&serialized));


### PR DESCRIPTION
This is a breaking change.

In particular, I am not sure if I am doing it correctly by using 	Higher-Rank Trait Bounds for traits since we don't really care about the lifetime of `'de` in enclosing structs.

HRTB: https://doc.rust-lang.org/nomicon/hrtb.html & https://stackoverflow.com/questions/35592750/how-does-for-syntax-differ-from-a-regular-lifetime-bound