### PR TITLE
Update to *ring* 0.9.4.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ chrono = "0.3"
 data-encoding = "1.2.0"
 lazy_static = "0.2"
 num = "0.1.37"
-ring = { version = "0.8.0", features = ["rsa_signing"] }
+ring = { version = "0.9.4", features = ["rsa_signing"] }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = { version = "1.0", features = ["preserve_order"] }


### PR DESCRIPTION
Before *ring* 0.9.3, it was possible to link multiple versions of *ring* into a program, e.g. if one version depended on *ring* 0.6 and another depended on *ring* 0.9. Unfortunately, this doesn't work, because the linker doesn't know to how to link *ring*'s C/asm code correctly in that kind of situation. *ring* 0.9.3 added a flag to its Cargo.toml to tell the Rust toolchain to stop allowing multiple versions of *ring* to be linked into the same program, to prevent any problems this may cause.

*ring* 0.9.4 was released with an update to make some crates easier to update to 0.9.x.

I'm planning to add ECDSA signing to an upcoming version of *ring* 0.9.x, which should also be useful for biscuit anyway.