### PR TITLE
Add APIs to `jws::Compact` for retrieval of parts without signature verification

### DIFF
--- a/src/jws.rs
+++ b/src/jws.rs
@@ -209,7 +209,7 @@ where
     /// Without decoding and verifying the JWS, retrieve a copy of the header.
     ///
     /// ## Warning
-    /// Use this at your own risk. It is not advisable to trust unverified content
+    /// Use this at your own risk. It is not advisable to trust unverified content.
     pub fn unverified_header(&self) -> Result<Header<H>, Error> {
         match *self {
             Compact::Decoded { .. } => Err(Error::UnsupportedOperation),
@@ -220,7 +220,7 @@ where
     /// Without decoding and verifying the JWS, retrieve a copy of the payload.
     ///
     /// ## Warning
-    /// Use this at your own risk. It is not advisable to trust unverified content
+    /// Use this at your own risk. It is not advisable to trust unverified content.
     pub fn unverified_payload(&self) -> Result<T, Error> {
         match *self {
             Compact::Decoded { .. } => Err(Error::UnsupportedOperation),
@@ -834,22 +834,6 @@ mod tests {
         let decoded: RegisteredHeader = not_err!(serde_json::from_str(&encoded));
         assert_eq!(decoded, expected);
     }
-
-    // let expected_claims = ClaimsSet::<PrivateClaims> {
-    //     registered: RegisteredClaims {
-    //         issuer: Some(not_err!(FromStr::from_str("https://www.acme.com"))),
-    //         subject: Some(not_err!(FromStr::from_str("John Doe"))),
-    //         audience: Some(SingleOrMultiple::Single(
-    //             not_err!(FromStr::from_str("htts://acme-customer.com")),
-    //         )),
-    //         not_before: Some(1234.into()),
-    //         ..Default::default()
-    //     },
-    //     private: PrivateClaims {
-    //         department: "Toilet Cleaning".to_string(),
-    //         company: "ACME".to_string(),
-    //     },
-    // };
 
     #[test]
     fn unverified_header_is_returned_correctly() {

--- a/src/jws.rs
+++ b/src/jws.rs
@@ -745,8 +745,8 @@ mod tests {
     fn compact_jws_decode_token_invalid_signature_hs256() {
         let token = Compact::<PrivateClaims, Empty>::new_encoded(
             "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.\
-                                                                    eyJzdWIiOiJiQGIuY29tIiwiY29tcGFueSI6IkFDTUUifQ.\
-                                                                    pKscJVk7-aHxfmQKlaZxh5uhuKhGMAa-1F5IX5mfUwI",
+             eyJzdWIiOiJiQGIuY29tIiwiY29tcGFueSI6IkFDTUUifQ.\
+             pKscJVk7-aHxfmQKlaZxh5uhuKhGMAa-1F5IX5mfUwI",
         );
         let claims = token.decode(
             &Secret::Bytes("secret".to_string().into_bytes()),
@@ -760,8 +760,8 @@ mod tests {
     fn compact_jws_decode_token_invalid_signature_rs256() {
         let token = Compact::<PrivateClaims, Empty>::new_encoded(
             "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.\
-                                                       eyJzdWIiOiJiQGIuY29tIiwiY29tcGFueSI6IkFDTUUifQ.\
-                                                       pKscJVk7-aHxfmQKlaZxh5uhuKhGMAa-1F5IX5mfUwI",
+             eyJzdWIiOiJiQGIuY29tIiwiY29tcGFueSI6IkFDTUUifQ.\
+             pKscJVk7-aHxfmQKlaZxh5uhuKhGMAa-1F5IX5mfUwI",
         );
         let public_key = Secret::public_key_from_file("test/fixtures/rsa_public_key.der").unwrap();
         let claims = token.decode(&public_key, SignatureAlgorithm::RS256);
@@ -773,8 +773,8 @@ mod tests {
     fn compact_jws_decode_token_wrong_algorithm() {
         let token = Compact::<PrivateClaims, Empty>::new_encoded(
             "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.\
-                                                       eyJzdWIiOiJiQGIuY29tIiwiY29tcGFueSI6IkFDTUUifQ.\
-                                                       pKscJVk7-aHxfmQKlaZxh5uhuKhGMAa-1F5IX5mfUwI",
+             eyJzdWIiOiJiQGIuY29tIiwiY29tcGFueSI6IkFDTUUifQ.\
+             pKscJVk7-aHxfmQKlaZxh5uhuKhGMAa-1F5IX5mfUwI",
         );
         let claims = token.decode(
             &Secret::Bytes("secret".to_string().into_bytes()),


### PR DESCRIPTION
Fixes #75 

![image](https://user-images.githubusercontent.com/983101/29393868-1d31c9ec-8339-11e7-9787-56611f3e163a.png)
