### PR TITLE
fix doc comment placement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: rust
 rust:
-- 1.27.2
+- 1.31.0
 - stable
 - beta
 - nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.0 (Unreleased)
+
+- Minimum Rust 1.31 is needed for editions support on dependencies
+
 ## Version 0.1.0 (2018-10-29)
 
 ### Breaking Change

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "biscuit"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Yong Wen Chua <me@yongwen.xyz>", "Vincent Prouillet <vincent@wearewizards.io>"]
 license = "MIT"
 readme = "README.md"

--- a/src/jwa.rs
+++ b/src/jwa.rs
@@ -23,8 +23,8 @@ const AES_GCM_TAG_SIZE: usize = 128 / 8;
 /// AES GCM Nonce length, in bytes
 const AES_GCM_NONCE_LENGTH: usize = 96 / 8;
 
-/// A zeroed AES GCM Nonce EncryptionOptions
 lazy_static! {
+    /// A zeroed AES GCM Nonce EncryptionOptions
     static ref AES_GCM_ZEROED_NONCE: EncryptionOptions = EncryptionOptions::AES_GCM {
         nonce: vec![0; AES_GCM_NONCE_LENGTH],
     };


### PR DESCRIPTION
rust-lang/rust#57882 is modifying the `unused_doc_comments` lint to fire on mistakenly documented macro expansions. A crater run detected that this crate will break due to this change, likely because of the use of `deny(unused_doc_comments)` or `deny(warnings)`.

While this kind of breakage is allowed under Rust's stability guarantees, I am opening PRs to affected crates to reduce the impact.

This PR protects your crate from future breakage by moving the doc comment inside the macro invocation.