### PR TITLE
Fix Clippy `trivially_copy_pass_by_ref` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,21 @@ The following functions have been renamed:
 - `jwk::JWK::octect_key` 🡒 `jwk::JWK::octet_key`
 - `jwk::AlgorithmParameters::octect_key` 🡒 `jwk::AlgorithmParameters::octet_key`
 
+### Clippy `trivially_copy_pass_by_ref` lint
+
+This release also fixes the
+[Clippy `trivially_copy_pass_by_ref` lint](https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref)
+by modifying function arguments that would have taken a reference of a 1 byte value that
+implements `Copy` to take the value of itself. This mainly affects all struct methods
+of the following types
+
+There should be no need to modify your code for this because the types are `Copy`.
+
+- `jwa::SignatureAlgorithm`
+- `jwa::KeyManagementAlgorithm`
+- `jwa::ContentEncryptionAlgorithm`
+- `jwk::KeyType`
+
 ## 0.3.1 (2019-07-30)
 
 There are no new features except for ring dependency changes.

--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -2,8 +2,6 @@
 //!
 //! This module implements code for JWK as described in [RFC7517](https://tools.ietf.org/html/rfc7517).
 
-#![allow(clippy::trivially_copy_pass_by_ref)]
-
 use std::fmt;
 
 use num::BigUint;
@@ -33,7 +31,7 @@ pub enum KeyType {
 
 impl KeyType {
     /// Description of the type of key
-    pub fn description(&self) -> &'static str {
+    pub fn description(self) -> &'static str {
         match self {
             KeyType::EllipticCurve => "Elliptic curve (EC) key",
             KeyType::RSA => "RSA Key",


### PR DESCRIPTION
See https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref

Fixes https://github.com/lawliet89/biscuit/issues/108

This PR replaces function arguments that would have taken a reference of a one byte value that are also `Copy`.

This mainly affects enums.