### PR TITLE
Add (de)serialization support for OKP key type

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           command: clippy
           args: --all-targets --all-features -- -D warnings
+        if: matrix.rust == 'stable' && matrix.os == 'ubuntu-latest'
 
       - uses: actions-rs/cargo@v1
         name: Build
@@ -56,6 +57,7 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+        if: matrix.rust == 'stable' && matrix.os == 'ubuntu-latest'
 
       - uses: actions-rs/cargo@v1
         name: Build Documentation

--- a/doc/supported.md
+++ b/doc/supported.md
@@ -77,7 +77,7 @@ for their use with the various algorithms is listed in the relevant section on t
 |   `EC`   |    ✔    |         |
 |   `RSA`  |    ✔    |         |
 |   `oct`  |    ✔    |         |
-|   `OKP`  |    ✘    |         |
+|   `OKP`  |    ✔    |         |
 
 ### JWK Parameters for Elliptic Curve Keys
 

--- a/src/jwa.rs
+++ b/src/jwa.rs
@@ -140,12 +140,12 @@ pub enum KeyManagementAlgorithm {
     /// ECDH-ES using Concat KDF and "A256KW" wrapping
     #[serde(rename = "ECDH-ES+A256KW")]
     ECDH_ES_A256KW,
-    /// Key wrapping with AES GCM using 128-bit key	alg
+    /// Key wrapping with AES GCM using 128-bit key alg
     A128GCMKW,
     /// Key wrapping with AES GCM using 192-bit key alg.
     /// This is [not supported](https://github.com/briansmith/ring/issues/112) by `ring`.
     A192GCMKW,
-    /// Key wrapping with AES GCM using 256-bit key	alg
+    /// Key wrapping with AES GCM using 256-bit key alg
     A256GCMKW,
     /// PBES2 with HMAC SHA-256 and "A128KW" wrapping
     #[serde(rename = "PBES2-HS256+A128KW")]
@@ -179,13 +179,13 @@ pub enum KeyManagementAlgorithmType {
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Serialize, Deserialize)]
 #[allow(non_camel_case_types)]
 pub enum ContentEncryptionAlgorithm {
-    /// AES_128_CBC_HMAC_SHA_256 authenticated encryption algorithm	enc
+    /// AES_128_CBC_HMAC_SHA_256 authenticated encryption algorithm enc
     #[serde(rename = "A128CBC-HS256")]
     A128CBC_HS256,
-    /// AES_192_CBC_HMAC_SHA_384 authenticated encryption algorithm	enc
+    /// AES_192_CBC_HMAC_SHA_384 authenticated encryption algorithm enc
     #[serde(rename = "A192CBC-HS384")]
     A192CBC_HS384,
-    /// AES_256_CBC_HMAC_SHA_512 authenticated encryption algorithm	enc
+    /// AES_256_CBC_HMAC_SHA_512 authenticated encryption algorithm enc
     #[serde(rename = "A256CBC-HS512")]
     A256CBC_HS512,
     /// AES GCM using 128-bit key
@@ -491,10 +491,10 @@ impl KeyManagementAlgorithm {
     ) -> Result<jwk::JWK<Empty>, Error> {
         let key = content_alg.generate_key()?;
         Ok(jwk::JWK {
-            algorithm: jwk::AlgorithmParameters::OctetKey {
+            algorithm: jwk::AlgorithmParameters::OctetKey(jwk::OctetKeyParameters {
                 value: key,
                 key_type: Default::default(),
-            },
+            }),
             common: jwk::CommonParameters {
                 public_key_use: Some(jwk::PublicKeyUse::Encryption),
                 algorithm: Some(Algorithm::ContentEncryption(content_alg)),
@@ -584,10 +584,10 @@ impl KeyManagementAlgorithm {
 
         let cek = aes_gcm_decrypt(algorithm, encrypted, key)?;
         Ok(jwk::JWK {
-            algorithm: jwk::AlgorithmParameters::OctetKey {
+            algorithm: jwk::AlgorithmParameters::OctetKey(jwk::OctetKeyParameters {
                 value: cek,
                 key_type: Default::default(),
-            },
+            }),
             common: jwk::CommonParameters {
                 public_key_use: Some(jwk::PublicKeyUse::Encryption),
                 algorithm: Some(Algorithm::ContentEncryption(content_alg)),
@@ -1094,10 +1094,10 @@ mod tests {
         let key = jwk::JWK::<Empty> {
             common: Default::default(),
             additional: Default::default(),
-            algorithm: jwk::AlgorithmParameters::OctetKey {
+            algorithm: jwk::AlgorithmParameters::OctetKey(jwk::OctetKeyParameters {
                 key_type: Default::default(),
                 value: key,
-            },
+            }),
         };
 
         let encrypted = not_err!(aes_gcm_encrypt(
@@ -1122,10 +1122,10 @@ mod tests {
         let key = jwk::JWK::<Empty> {
             common: Default::default(),
             additional: Default::default(),
-            algorithm: jwk::AlgorithmParameters::OctetKey {
+            algorithm: jwk::AlgorithmParameters::OctetKey(jwk::OctetKeyParameters {
                 key_type: Default::default(),
                 value: key,
-            },
+            }),
         };
 
         let encrypted = not_err!(aes_gcm_encrypt(
@@ -1150,10 +1150,10 @@ mod tests {
         let key = jwk::JWK::<Empty> {
             common: Default::default(),
             additional: Default::default(),
-            algorithm: jwk::AlgorithmParameters::OctetKey {
+            algorithm: jwk::AlgorithmParameters::OctetKey(jwk::OctetKeyParameters {
                 key_type: Default::default(),
                 value: key,
-            },
+            }),
         };
 
         let encrypted = not_err!(aes_gcm_encrypt(
@@ -1177,10 +1177,10 @@ mod tests {
         let key = jwk::JWK::<Empty> {
             common: Default::default(),
             additional: Default::default(),
-            algorithm: jwk::AlgorithmParameters::OctetKey {
+            algorithm: jwk::AlgorithmParameters::OctetKey(jwk::OctetKeyParameters {
                 key_type: Default::default(),
                 value: key,
-            },
+            }),
         };
 
         let encrypted = not_err!(aes_gcm_encrypt(
@@ -1205,10 +1205,10 @@ mod tests {
         let key = jwk::JWK::<Empty> {
             common: Default::default(),
             additional: Default::default(),
-            algorithm: jwk::AlgorithmParameters::OctetKey {
+            algorithm: jwk::AlgorithmParameters::OctetKey(jwk::OctetKeyParameters {
                 key_type: Default::default(),
                 value: key,
-            },
+            }),
         };
 
         let cek_alg = KeyManagementAlgorithm::DirectSymmetricKey;
@@ -1228,10 +1228,10 @@ mod tests {
         let key = jwk::JWK::<Empty> {
             common: Default::default(),
             additional: Default::default(),
-            algorithm: jwk::AlgorithmParameters::OctetKey {
+            algorithm: jwk::AlgorithmParameters::OctetKey(jwk::OctetKeyParameters {
                 key_type: Default::default(),
                 value: key,
-            },
+            }),
         };
 
         let cek_alg = KeyManagementAlgorithm::A128GCMKW;
@@ -1257,10 +1257,10 @@ mod tests {
         let key = jwk::JWK::<Empty> {
             common: Default::default(),
             additional: Default::default(),
-            algorithm: jwk::AlgorithmParameters::OctetKey {
+            algorithm: jwk::AlgorithmParameters::OctetKey(jwk::OctetKeyParameters {
                 key_type: Default::default(),
                 value: key,
-            },
+            }),
         };
 
         let cek_alg = KeyManagementAlgorithm::A256GCMKW;
@@ -1285,10 +1285,10 @@ mod tests {
         let key = jwk::JWK::<Empty> {
             common: Default::default(),
             additional: Default::default(),
-            algorithm: jwk::AlgorithmParameters::OctetKey {
+            algorithm: jwk::AlgorithmParameters::OctetKey(jwk::OctetKeyParameters {
                 key_type: Default::default(),
                 value: key,
-            },
+            }),
         };
 
         let options = EncryptionOptions::AES_GCM {
@@ -1317,10 +1317,10 @@ mod tests {
         let key = jwk::JWK::<Empty> {
             common: Default::default(),
             additional: Default::default(),
-            algorithm: jwk::AlgorithmParameters::OctetKey {
+            algorithm: jwk::AlgorithmParameters::OctetKey(jwk::OctetKeyParameters {
                 key_type: Default::default(),
                 value: key,
-            },
+            }),
         };
 
         let options = EncryptionOptions::AES_GCM {
@@ -1365,10 +1365,10 @@ mod tests {
         let key = jwk::JWK::<Empty> {
             common: Default::default(),
             additional: Default::default(),
-            algorithm: jwk::AlgorithmParameters::OctetKey {
+            algorithm: jwk::AlgorithmParameters::OctetKey(jwk::OctetKeyParameters {
                 key_type: Default::default(),
                 value: key,
-            },
+            }),
         };
 
         let options = EncryptionOptions::AES_GCM {
@@ -1393,10 +1393,10 @@ mod tests {
         let key = jwk::JWK::<Empty> {
             common: Default::default(),
             additional: Default::default(),
-            algorithm: jwk::AlgorithmParameters::OctetKey {
+            algorithm: jwk::AlgorithmParameters::OctetKey(jwk::OctetKeyParameters {
                 key_type: Default::default(),
                 value: key,
-            },
+            }),
         };
 
         let options = EncryptionOptions::AES_GCM {

--- a/src/jwe.rs
+++ b/src/jwe.rs
@@ -632,10 +632,10 @@ mod tests {
         jwk::JWK {
             common: Default::default(),
             additional: Default::default(),
-            algorithm: jwk::AlgorithmParameters::OctetKey {
+            algorithm: jwk::AlgorithmParameters::OctetKey(jwk::OctetKeyParameters {
                 key_type: Default::default(),
                 value: key,
-            },
+            }),
         }
     }
 

--- a/src/jws.rs
+++ b/src/jws.rs
@@ -172,7 +172,7 @@ where
 
                 let secret = match &jwk.algorithm {
                     AlgorithmParameters::RSA(rsa) => rsa.jws_public_key_secret(),
-                    AlgorithmParameters::OctetKey { value, .. } => Secret::Bytes(value.clone()),
+                    AlgorithmParameters::OctetKey(oct) => Secret::Bytes(oct.value.clone()),
                     _ => Err(ValidationError::UnsupportedKeyAlgorithm)?,
                 };
 
@@ -659,8 +659,7 @@ mod tests {
 
     #[test]
     fn compact_jws_round_trip_none() {
-        let expected_token =
-            "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.\
+        let expected_token = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.\
              eyJpc3MiOiJodHRwczovL3d3dy5hY21lLmNvbS8iLCJzdWIiOiJKb2huIERvZSIsImF1ZCI6Imh0dHM6Ly9\
              hY21lLWN1c3RvbWVyLmNvbS8iLCJuYmYiOjEyMzQsImNvbXBhbnkiOiJBQ01FIiwiZGVwYXJ0bWVudCI6Il\
              RvaWxldCBDbGVhbmluZyJ9.";
@@ -898,8 +897,7 @@ mod tests {
 
     #[test]
     fn compact_jws_round_trip_hs256_for_bytes_payload() {
-        let expected_token =
-            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImN0eSI6IlJhbmRvbSBieXRlcyJ9.\
+        let expected_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImN0eSI6IlJhbmRvbSBieXRlcyJ9.\
              eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcG\
              xlLmNvbS9pc19yb290Ijp0cnVlfQ.E5ahoj_gMO8WZzSUhquWuBkPLGZm18zaLbyHUQA7TIs";
         let payload: Vec<u8> = vec![

--- a/src/jws.rs
+++ b/src/jws.rs
@@ -659,7 +659,8 @@ mod tests {
 
     #[test]
     fn compact_jws_round_trip_none() {
-        let expected_token = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.\
+        let expected_token =
+            "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.\
              eyJpc3MiOiJodHRwczovL3d3dy5hY21lLmNvbS8iLCJzdWIiOiJKb2huIERvZSIsImF1ZCI6Imh0dHM6Ly9\
              hY21lLWN1c3RvbWVyLmNvbS8iLCJuYmYiOjEyMzQsImNvbXBhbnkiOiJBQ01FIiwiZGVwYXJ0bWVudCI6Il\
              RvaWxldCBDbGVhbmluZyJ9.";
@@ -897,7 +898,8 @@ mod tests {
 
     #[test]
     fn compact_jws_round_trip_hs256_for_bytes_payload() {
-        let expected_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImN0eSI6IlJhbmRvbSBieXRlcyJ9.\
+        let expected_token =
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImN0eSI6IlJhbmRvbSBieXRlcyJ9.\
              eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcG\
              xlLmNvbS9pc19yb290Ijp0cnVlfQ.E5ahoj_gMO8WZzSUhquWuBkPLGZm18zaLbyHUQA7TIs";
         let payload: Vec<u8> = vec![

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,6 @@
     non_upper_case_globals,
     overflowing_literals,
     path_statements,
-    plugin_as_library,
     stable_features,
     trivial_casts,
     trivial_numeric_casts,


### PR DESCRIPTION
Also refactored `AlgorithmParameters::OctetKey` to be more consistent with the other enum variants.