### PR TITLE
Fix the jwk field (.web_key) to contain a proper JWK

### DIFF
--- a/src/jws.rs
+++ b/src/jws.rs
@@ -624,11 +624,11 @@ pub struct RegisteredHeader {
     #[serde(rename = "jku", skip_serializing_if = "Option::is_none")]
     pub web_key_url: Option<String>,
 
-    /// The JSON Web Key. This is currently not implemented (correctly).
+    /// The JSON Web Key.
     /// Serialized to `jwk`.
     /// Defined in [RFC7515#4.1.3](https://tools.ietf.org/html/rfc7515#section-4.1.3).
     #[serde(rename = "jwk", skip_serializing_if = "Option::is_none")]
-    pub web_key: Option<String>,
+    pub web_key: Option<jwk::JWK<Empty>>,
 
     /// The Key ID. This is currently not implemented (correctly).
     /// Serialized to `kid`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,8 +51,7 @@
 #![allow(
     missing_copy_implementations,
     missing_debug_implementations,
-    unknown_lints,
-    clippy::unknown_clippy_lints
+    unknown_lints
 )]
 #![allow(clippy::try_err, clippy::needless_doctest_main)]
 #![deny(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -684,9 +684,9 @@ impl From<DateTime<Utc>> for Timestamp {
     }
 }
 
-impl Into<DateTime<Utc>> for Timestamp {
-    fn into(self) -> DateTime<Utc> {
-        self.0
+impl From<Timestamp> for DateTime<Utc> {
+    fn from(ts: Timestamp) -> Self {
+        ts.0
     }
 }
 


### PR DESCRIPTION
The jwk field was unusable prior to this change; a string was not valid in this context.