### PR TITLE
Add Support for P-256

### DIFF
--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -368,6 +368,18 @@ pub struct EllipticCurveKeyParameters {
     pub d: Option<Vec<u8>>,
 }
 
+impl EllipticCurveKeyParameters {
+    /// Construct a `jws::Secret` EC public key for signature verification
+    pub fn jws_public_key_secret(&self) -> jws::Secret {
+        let mut vec = Vec::with_capacity(self.x.len() + self.y.len() + 1);
+        // to sec1 uncompressed
+        vec.push(0x04);
+        vec.extend(self.x.iter().copied());
+        vec.extend(self.y.iter().copied());
+        jws::Secret::PublicKey(vec)
+    }
+}
+
 /// Parameters for a RSA Key
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Default)]
 pub struct RSAKeyParameters {

--- a/src/jws/compact.rs
+++ b/src/jws/compact.rs
@@ -272,16 +272,13 @@ where
                     Err(ValidationError::UnsupportedKeyAlgorithm)?
                 }
 
-                if !secrets
-                    .iter()
-                    .any(|secret| {
-                        header
-                            .registered
-                            .algorithm
-                            .verify(signature.as_ref(), payload.as_ref(), secret)
-                            .is_ok()
-                    })
-                {
+                if !secrets.iter().any(|secret| {
+                    header
+                        .registered
+                        .algorithm
+                        .verify(signature.as_ref(), payload.as_ref(), secret)
+                        .is_ok()
+                }) {
                     Err(ValidationError::InvalidSignature)?
                 }
 

--- a/src/jws/compact.rs
+++ b/src/jws/compact.rs
@@ -272,16 +272,15 @@ where
                     Err(ValidationError::UnsupportedKeyAlgorithm)?
                 }
 
-                if secrets
+                if !secrets
                     .iter()
-                    .find(|secret| {
+                    .any(|secret| {
                         header
                             .registered
                             .algorithm
                             .verify(signature.as_ref(), payload.as_ref(), secret)
                             .is_ok()
                     })
-                    .is_none()
                 {
                     Err(ValidationError::InvalidSignature)?
                 }
@@ -1116,8 +1115,8 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "UnsupportedKeyAlgorithm")]
-    fn compact_jws_decode_with_jwks_key_type_not_supported() {
+    #[should_panic(expected = "InvalidSignature")]
+    fn compact_jws_decode_with_p256_invalid_signature() {
         let token = Compact::<PrivateClaims, Empty>::new_encoded(
             "eyJhbGciOiAiRVMyNTYiLCJ0eXAiOiAiSldUIiwia2lkIjogImtleTAifQ.\
              eyJjb21wYW55IjoiQUNNRSIsImRlcGFydG1lbnQiOiJUb2lsZXQgQ2xlYW5pbmcifQ.\

--- a/src/jws/compact.rs
+++ b/src/jws/compact.rs
@@ -196,6 +196,7 @@ where
                 };
 
                 let secret = match &jwk.algorithm {
+                    AlgorithmParameters::EllipticCurve(ec) => ec.jws_public_key_secret(),
                     AlgorithmParameters::RSA(rsa) => rsa.jws_public_key_secret(),
                     AlgorithmParameters::OctetKey(oct) => Secret::Bytes(oct.value.clone()),
                     _ => Err(ValidationError::UnsupportedKeyAlgorithm)?,
@@ -204,6 +205,63 @@ where
                 algorithm
                     .verify(signature.as_ref(), payload.as_ref(), &secret)
                     .map_err(|_| ValidationError::InvalidSignature)?;
+
+                let decoded_claims: T = encoded.part(1)?;
+
+                Ok(Self::new_decoded(header, decoded_claims))
+            }
+        }
+    }
+
+    /// Decode a token into the JWT struct and verify its signature using a JWKS, ignoring kid.
+    ///
+    /// If the JWK does not contain an optional algorithm parameter, you will have to specify
+    /// the expected algorithm or an error will be returned.
+    ///
+    /// If the JWK specifies an algorithm and you provide an expected algorithm,
+    /// both will be checked for equality. If they do not match, an error will be returned.
+    ///
+    /// If the token or its signature is invalid, it will return an error
+    pub fn decode_with_jwks_ignore_kid<J>(
+        &self,
+        jwks: &JWKSet<J>,
+    ) -> Result<Self, Error> {
+        match *self {
+            Compact::Decoded { .. } => Err(Error::UnsupportedOperation),
+            Compact::Encoded(ref encoded) => {
+                if encoded.len() != 3 {
+                    Err(DecodeError::PartsLengthError {
+                        actual: encoded.len(),
+                        expected: 3,
+                    })?
+                }
+
+                let signature: Vec<u8> = encoded.part(2)?;
+                let payload = &encoded.parts[0..2].join(".");
+
+                let header: Header<H> = encoded.part(0)?;
+
+                let secrets = jwks.keys.iter().filter_map(|jwk| {
+                    let jwk_alg = jwk.common.algorithm.and_then(|it| if let Algorithm::Signature(alg) = it { Some(alg) } else { None });
+                    // if no algorithm is set it will try the key anyway. if it is it will only accept the right one
+                    if jwk.common.algorithm.is_some() && Some(header.registered.algorithm) != jwk_alg {
+                        return None
+                    }
+                    match &jwk.algorithm {
+                        AlgorithmParameters::EllipticCurve(ec) => Some(ec.jws_public_key_secret()),
+                        AlgorithmParameters::RSA(rsa) => Some(rsa.jws_public_key_secret()),
+                        AlgorithmParameters::OctetKey(oct) => Some(Secret::Bytes(oct.value.clone())),
+                        _ => None,
+                    }
+                }).collect::<Vec<_>>();
+
+                if secrets.is_empty() {
+                    Err(ValidationError::UnsupportedKeyAlgorithm)?
+                }
+
+                if secrets.iter().find(|secret| header.registered.algorithm.verify(signature.as_ref(), payload.as_ref(), secret).is_ok()).is_none() {
+                    Err(ValidationError::InvalidSignature)?
+                }
 
                 let decoded_claims: T = encoded.part(1)?;
 
@@ -548,6 +606,29 @@ mod tests {
 
         let token = Compact::<ClaimsSet<serde_json::Value>, Empty>::new_encoded(jwt);
         let _ = not_err!(token.into_decoded(&signing_secret, SignatureAlgorithm::ES256));
+    }
+
+    #[test]
+    fn compact_jws_verify_es256_jwks() {
+        let jwks: JWKSet<Empty> = serde_json::from_str(
+            r#"{
+                "keys": [
+                            {
+                                "kty": "EC",
+                                "crv": "P-256",
+                                "x": "Nyf5aq1BaIfddcwuMzw9jgbc35aLYCRXlEmiuALvyJE",
+                                "y": "9jjHUc9ofm_5ooDhG3A2WF5gyjK7Rpw-V5mKKJ4IYKY"
+                            }
+                ]
+            }"#,
+            ).unwrap();
+        let jwt = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.\
+                   eyJ0b2tlbl90eXBlIjoic2VydmljZSIsImlhdCI6MTQ5MjkzODU4OH0.\
+                   do_XppIOFthPWlTXL95CIBfgRdyAxbcIsUfM0YxMjCjqvp4ehHFA3I-JasABKzC8CAy4ndhCHsZdpAtK\
+                   kqZMEA";
+
+        let token = Compact::<ClaimsSet<serde_json::Value>, Empty>::new_encoded(jwt);
+        let _ = not_err!(token.decode_with_jwks_ignore_kid(&jwks));
     }
 
     #[test]


### PR DESCRIPTION
- Solved #155 with `EllipticCurveKeyParameters.jws_public_key_secret`
- Solved #256 
- added `decode_with_jwks_ignore_kid` so to have a more relaxed verification against jwks.