### PR TITLE
Replace unmaintained actions-rs/* actions in CI workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,52 +25,32 @@ jobs:
       - uses: actions/checkout@v3
         name: Checkout
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         name: Verify Rust Toolchain
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
           components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@v2
         name: Rust Cache
 
-      - uses: actions-rs/cargo@v1
+      - run: cargo fmt --all -- --check
         name: Format Check
-        with:
-          command: fmt
-          args: --all -- --check
         if: matrix.rust == 'stable' && matrix.os == 'ubuntu-latest'
 
-      - uses: actions-rs/cargo@v1
+      - run: cargo clippy --all-targets --all-features -- -D warnings
         name: Clippy Lint (Stable)
-        with:
-          command: clippy
-          args: --all-targets --all-features -- -D warnings
         if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
 
-      - uses: actions-rs/cargo@v1
+      - run: cargo clippy --all-targets --all-features -- -D warnings -A "clippy::upper_case_acronyms"
         name: Clippy Lint (Non-stable)
-        with:
-          command: clippy
-          args: --all-targets --all-features -- -D warnings -A "clippy::upper_case_acronyms"
         if: matrix.os == 'ubuntu-latest' && (matrix.rust == 'beta' || matrix.rust == 'nightly')
 
-      - uses: actions-rs/cargo@v1
+      - run: cargo build --verbose --all-features
         name: Build
-        with:
-          command: build
-          args: --verbose --all-features
 
-      - uses: actions-rs/cargo@v1
+      - run: cargo test --all-features
         name: Unit Tests
-        with:
-          command: test
-          args: --all-features
 
-      - uses: actions-rs/cargo@v1
+      - run: cargo doc --no-deps --all-features
         name: Build Documentation
-        with:
-          command: doc
-          args: --no-deps --all-features


### PR DESCRIPTION
Basically all of the `actions-rs/*` actions are unmaintained. See <https://github.com/actions-rs/toolchain/issues/216> for more information. Due to their age they generate several warnings in CI runs, for example in https://github.com/lawliet89/biscuit/actions/runs/4825460026:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions-rs/toolchain@v1, actions-rs/cargo@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

To get rid of those warnings the occurrences of `actions-rs/toolchain` are replaced by [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain), and the occurrences of `actions-rs/cargo` are replaced by direct invocations of `cargo`.